### PR TITLE
posición de inicio mas arreglo al prender/apagar el GPS

### DIFF
--- a/app/src/main/java/ar/edu/unlam/mobile/scaffolding/ui/components/CreateEventSheet.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffolding/ui/components/CreateEventSheet.kt
@@ -35,7 +35,6 @@ import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.PhotoCamera
@@ -246,19 +245,10 @@ fun CreateEventSheet(
                 onValueChange = { name = it },
                 textStyle = MaterialTheme.typography.bodyLarge,
                 label = { Text("Nombre del evento") },
-                placeholder = {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            imageVector = Icons.Default.Create,
-                            contentDescription = "Nombre del evento",
-                            tint = MaterialTheme.colorScheme.secondary,
-                        )
-                        Text("Nombre del evento")
-                    }
-                },
                 modifier = Modifier.fillMaxWidth(),
                 colors =
                     TextFieldDefaults.colors(
+                        focusedIndicatorColor = MaterialTheme.colorScheme.primary,
                         focusedContainerColor = Color.Transparent,
                         unfocusedContainerColor = Color.Transparent,
                     ),
@@ -271,6 +261,12 @@ fun CreateEventSheet(
                 textStyle = MaterialTheme.typography.bodyLarge,
                 label = { Text("Descripción") },
                 modifier = Modifier.fillMaxWidth(),
+                colors =
+                    TextFieldDefaults.colors(
+                        focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                    ),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             )
 

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffolding/ui/components/HomeMap.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffolding/ui/components/HomeMap.kt
@@ -3,6 +3,11 @@ package ar.edu.unlam.mobile.scaffolding.ui.components
 import android.graphics.Color
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
@@ -10,6 +15,7 @@ import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
 import ar.edu.unlam.mobile.scaffolding.domain.event.model.SuggestedEvent
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import kotlinx.coroutines.delay
 import org.osmdroid.config.Configuration
 import org.osmdroid.events.MapEventsReceiver
 import org.osmdroid.events.MapListener
@@ -35,164 +41,171 @@ fun NearbyMap(
     userLocation: GeoPoint?,
 ) {
     val context = LocalContext.current
+    var initMap by remember { mutableStateOf(false) }
 
-    AndroidView(
-        modifier = modifier.fillMaxSize(),
-        factory = { context ->
-            MapView(context).apply {
-                Configuration.getInstance().load(
-                    context,
-                    PreferenceManager.getDefaultSharedPreferences(context),
-                )
-                setTileSource(TileSourceFactory.MAPNIK)
-                setMultiTouchControls(true)
-                controller.setZoom(mapProperties.zoom)
-                controller.setCenter(userLocation ?: GeoPoint(-34.6037, -58.3816))
+    LaunchedEffect(Unit) {
+        delay(500)
+        initMap = true
+    }
 
-                // Esto se usa para rotar la brujula (por gestos) enviando la orientacion actual del mapa
-                addMapListener(
-                    object : MapListener {
-                        private var lastOrientation = 0f
-
-                        override fun onScroll(event: ScrollEvent?): Boolean {
-                            val current = mapOrientation
-                            if (current != lastOrientation) {
-                                rotationChanged(current)
-                                lastOrientation = current
-                            }
-                            return false
-                        }
-
-                        override fun onZoom(event: ZoomEvent?) = false
-                    },
-                )
-
-                // Rotacion por gestos
-                val rotationGesture = RotationGestureOverlay(this)
-                overlays.add(rotationGesture)
-
-                // Eventos con click
-                val eventsReceiver =
-                    object : MapEventsReceiver {
-                        override fun singleTapConfirmedHelper(p: GeoPoint?): Boolean = false
-
-                        override fun longPressHelper(p: GeoPoint?): Boolean {
-                            p?.let(onLongPress)
-                            return true
-                        }
-                    }
-                val eventsOverlay = MapEventsOverlay(eventsReceiver)
-                overlays.add(eventsOverlay)
-
-                tag =
-                    mapOf(
-                        "gesture" to rotationGesture,
-                        "events" to eventsOverlay,
+    if (userLocation != null || initMap) {
+        AndroidView(
+            modifier = modifier.fillMaxSize(),
+            factory = { context ->
+                MapView(context).apply {
+                    Configuration.getInstance().load(
+                        context,
+                        PreferenceManager.getDefaultSharedPreferences(context),
                     )
-            }
-        },
-        update = { mv ->
-            val tagMap = mv.tag as Map<*, *>
-            val rotationGestureOverlay = tagMap["gesture"] as RotationGestureOverlay
-            val eventsOverlay = tagMap["events"] as MapEventsOverlay
+                    setTileSource(TileSourceFactory.MAPNIK)
+                    setMultiTouchControls(true)
+                    controller.setZoom(mapProperties.zoom)
+                    controller.setCenter(userLocation ?: GeoPoint(-34.6037, -58.3816))
 
-            // Habilita la rotación por gestos
-            rotationGestureOverlay.isEnabled = mapProperties.rotationByGesture
+                    // Esto se usa para rotar la brujula (por gestos) enviando la orientacion actual del mapa
+                    addMapListener(
+                        object : MapListener {
+                            private var lastOrientation = 0f
 
-            // La rotacion por sensor esta en la screen y cuando la recives la rotacion del celu
-            // la invierte para que el mapa apunte a la direccion de la brujula correctamente
-            if (mapProperties.rotationBySensor) {
-                mv.mapOrientation = mapProperties.mapOrientation
-            }
-
-            if (mapProperties.enableLongPress) {
-                if (!mv.overlays.contains(eventsOverlay)) {
-                    mv.overlays.add(eventsOverlay)
-                }
-            } else {
-                mv.overlays.remove(eventsOverlay)
-            }
-
-            mv.overlays.removeAll { it is Marker }
-
-            mapProperties.longPressPoint?.let { point ->
-                val longPressMarker =
-                    Marker(mv).apply {
-                        position = GeoPoint(point.latitude, point.longitude)
-                        title = "Punto seleccionado"
-                        setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
-                        icon = ContextCompat.getDrawable(context, R.drawable.marker_default)
-                        icon?.setTint(Color.GREEN)
-
-                        setOnMarkerClickListener { _, _ ->
-                            onLongPress(null)
-                            true
-                        }
-                    }
-                mv.overlays.add(longPressMarker)
-            }
-
-            //  Tu ubicación
-            userLocation?.let {
-                val myMarker =
-                    Marker(mv).apply {
-                        position = GeoPoint(it.latitude, it.longitude)
-                        title = "Estás aquí"
-                        setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
-                        icon = ContextCompat.getDrawable(context, R.drawable.marker_default)
-                        icon?.setTint(Color.BLUE)
-
-                        // Esto lo puse para simular que si tocas tu posicion el punto verde desaparezca
-                        // y asi fuera como que seleccionaste tu ubicacion
-                        setOnMarkerClickListener { _, _ ->
-                            onLongPress(null)
-                            if (this.isInfoWindowShown) {
-                                this.closeInfoWindow()
-                            } else {
-                                this.showInfoWindow()
+                            override fun onScroll(event: ScrollEvent?): Boolean {
+                                val current = mapOrientation
+                                if (current != lastOrientation) {
+                                    rotationChanged(current)
+                                    lastOrientation = current
+                                }
+                                return false
                             }
-                            true
+
+                            override fun onZoom(event: ZoomEvent?) = false
+                        },
+                    )
+
+                    // Rotacion por gestos
+                    val rotationGesture = RotationGestureOverlay(this)
+                    overlays.add(rotationGesture)
+
+                    // Eventos con click
+                    val eventsReceiver =
+                        object : MapEventsReceiver {
+                            override fun singleTapConfirmedHelper(p: GeoPoint?): Boolean = false
+
+                            override fun longPressHelper(p: GeoPoint?): Boolean {
+                                p?.let(onLongPress)
+                                return true
+                            }
                         }
+                    val eventsOverlay = MapEventsOverlay(eventsReceiver)
+                    overlays.add(eventsOverlay)
+
+                    tag =
+                        mapOf(
+                            "gesture" to rotationGesture,
+                            "events" to eventsOverlay,
+                        )
+                }
+            },
+            update = { mv ->
+                val tagMap = mv.tag as Map<*, *>
+                val rotationGestureOverlay = tagMap["gesture"] as RotationGestureOverlay
+                val eventsOverlay = tagMap["events"] as MapEventsOverlay
+
+                // Habilita la rotación por gestos
+                rotationGestureOverlay.isEnabled = mapProperties.rotationByGesture
+
+                // La rotacion por sensor esta en la screen y cuando la recives la rotacion del celu
+                // la invierte para que el mapa apunte a la direccion de la brujula correctamente
+                if (mapProperties.rotationBySensor) {
+                    mv.mapOrientation = mapProperties.mapOrientation
+                }
+
+                if (mapProperties.enableLongPress) {
+                    if (!mv.overlays.contains(eventsOverlay)) {
+                        mv.overlays.add(eventsOverlay)
                     }
-                mv.overlays.add(myMarker)
-            }
+                } else {
+                    mv.overlays.remove(eventsOverlay)
+                }
 
-            //  Eventos con click
-            nearbyEvents.forEach { evento ->
-                val marker =
-                    Marker(mv).apply {
-                        position = GeoPoint(evento.lat, evento.lng)
-                        title = evento.title
-                        setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
-                        icon = ContextCompat.getDrawable(context, R.drawable.marker_default)
-                        icon?.setTint(Color.RED)
+                mv.overlays.removeAll { it is Marker }
 
-                        // Acción al hacer clic
-                        setOnMarkerClickListener { _, _ ->
-                            onEventoClick(evento)
-                            true // devuelve true para indicar que el evento fue manejado
+                mapProperties.longPressPoint?.let { point ->
+                    val longPressMarker =
+                        Marker(mv).apply {
+                            position = GeoPoint(point.latitude, point.longitude)
+                            title = "Punto seleccionado"
+                            setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
+                            icon = ContextCompat.getDrawable(context, R.drawable.marker_default)
+                            icon?.setTint(Color.GREEN)
+
+                            setOnMarkerClickListener { _, _ ->
+                                onLongPress(null)
+                                true
+                            }
                         }
-                    }
-                mv.overlays.add(marker)
-            }
+                    mv.overlays.add(longPressMarker)
+                }
 
-            print("Dibujando ${nearbyEvents.size} eventos en el mapa.")
+                //  Tu ubicación
+                userLocation?.let {
+                    val myMarker =
+                        Marker(mv).apply {
+                            position = GeoPoint(it.latitude, it.longitude)
+                            title = "Estás aquí"
+                            setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
+                            icon = ContextCompat.getDrawable(context, R.drawable.marker_default)
+                            icon?.setTint(Color.BLUE)
 
-            if (mapProperties.targetLocation != null) {
-                val targetPoint = mapProperties.targetLocation
-                mv.controller.animateTo(targetPoint)
-            }
+                            // Esto lo puse para simular que si tocas tu posicion el punto verde desaparezca
+                            // y asi fuera como que seleccionaste tu ubicacion
+                            setOnMarkerClickListener { _, _ ->
+                                onLongPress(null)
+                                if (this.isInfoWindowShown) {
+                                    this.closeInfoWindow()
+                                } else {
+                                    this.showInfoWindow()
+                                }
+                                true
+                            }
+                        }
+                    mv.overlays.add(myMarker)
+                }
 
-            mv.invalidate()
-        },
-        onRelease = { mv ->
-            mv.onDetach()
-        },
-    )
+                //  Eventos con click
+                nearbyEvents.forEach { evento ->
+                    val marker =
+                        Marker(mv).apply {
+                            position = GeoPoint(evento.lat, evento.lng)
+                            title = evento.title
+                            setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
+                            icon = ContextCompat.getDrawable(context, R.drawable.marker_default)
+                            icon?.setTint(Color.RED)
+
+                            // Acción al hacer clic
+                            setOnMarkerClickListener { _, _ ->
+                                onEventoClick(evento)
+                                true // devuelve true para indicar que el evento fue manejado
+                            }
+                        }
+                    mv.overlays.add(marker)
+                }
+
+                print("Dibujando ${nearbyEvents.size} eventos en el mapa.")
+
+                if (mapProperties.targetLocation != null) {
+                    val targetPoint = mapProperties.targetLocation
+                    mv.controller.animateTo(targetPoint)
+                }
+
+                mv.invalidate()
+            },
+            onRelease = { mv ->
+                mv.onDetach()
+            },
+        )
+    }
 }
 
 data class MapProperties(
-    val center: GeoPoint? = null,
     val targetLocation: GeoPoint? = null,
     val zoom: Double = 15.0,
     val mapOrientation: Float = 0f,

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffolding/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffolding/ui/screens/HomeScreen.kt
@@ -61,7 +61,6 @@ fun HomeScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val searchBarState by viewModel.searchUiState.collectAsStateWithLifecycle()
-    val selectedEvent by viewModel.selectedEvent.collectAsState()
 
     var showCreateEventDialog by remember { mutableStateOf(false) }
     var isSessionActive by remember { mutableStateOf(false) }
@@ -100,7 +99,7 @@ fun HomeScreen(
             val locationCallback =
                 object : LocationCallback() {
                     override fun onLocationResult(result: LocationResult) {
-                        result.lastLocation?.let { viewModel::setUserLocation }
+                        result.lastLocation?.let { viewModel.setUserLocation(it) }
                     }
                 }
 
@@ -165,11 +164,11 @@ fun HomeScreen(
                 // Estado para animar tarjeta del evento seleccionado
                 var showEventCard by remember { mutableStateOf(false) }
 
-                LaunchedEffect(selectedEvent) {
-                    showEventCard = selectedEvent != null
+                LaunchedEffect(uiState.selectedEvent) {
+                    showEventCard = uiState.selectedEvent != null
                 }
 
-                selectedEvent?.let { event ->
+                uiState.selectedEvent?.let { event ->
                     Column(
                         modifier =
                             Modifier

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffolding/ui/screens/HomeViewModel.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffolding/ui/screens/HomeViewModel.kt
@@ -47,6 +47,7 @@ import javax.inject.Inject
 
 data class HomeUIState(
     val eventList: List<SuggestedEvent> = emptyList(),
+    val selectedEvent: EventItem? = null,
     val mapProperties: MapProperties = MapProperties(),
     val helloMessageState: MessageUIState,
     val userLocation: GeoPoint? = null,
@@ -92,8 +93,7 @@ class HomeViewModel
         private var mapEventJob: Job? = null
         private var searchEventJob: Job? = null
         private var navigationJob: Job? = null
-        private val _selectedEvent = MutableStateFlow<EventItem?>(null)
-        val selectedEvent = _selectedEvent.asStateFlow()
+        private var locationTimeoutJob: Job? = null
 
         init {
             _uiState.value = HomeUIState(helloMessageState = MessageUIState.Success("2b"))
@@ -121,11 +121,16 @@ class HomeViewModel
         // Esto deberia hacer si tienes los permisos te coloque al iniciar en tu posicion en el mapa,
         // de momento no lo hace, estoy en eso.
         fun setUserLocation(location: Location) {
+            locationTimeoutJob?.cancel()
+            locationTimeoutJob =
+                viewModelScope.launch {
+                    delay(6000L)
+                    _uiState.update { it.copy(userLocation = null) }
+                }
             val userLocation = GeoPoint(location.latitude, location.longitude)
             _uiState.update {
                 it.copy(
                     userLocation = userLocation,
-                    mapProperties = it.mapProperties.copy(center = userLocation),
                 )
             }
         }
@@ -379,12 +384,16 @@ class HomeViewModel
                 getEventByIdUseCase(eventId).collect { resource ->
                     when (resource) {
                         is Resource.Success -> {
-                            _selectedEvent.value = resource.data
+                            _uiState.update { currentState ->
+                                currentState.copy(selectedEvent = resource.data)
+                            }
                             setTargetLocation(GeoPoint(resource.data.lat, resource.data.lng))
                         }
                         is Resource.Error -> {
                             Log.e("HomeViewModel", "Evento no encontrado: ${resource.message}")
-                            _selectedEvent.value = null
+                            _uiState.update { currentState ->
+                                currentState.copy(selectedEvent = null)
+                            }
                         }
                     }
                 }
@@ -392,6 +401,8 @@ class HomeViewModel
         }
 
         fun clearSelectedEvent() {
-            _selectedEvent.value = null
+            _uiState.update { currentState ->
+                currentState.copy(selectedEvent = null)
+            }
         }
     }


### PR DESCRIPTION
 Ahora el mapa vuelve a comenzar en tu posición actual si entras en la aplicación o la pantalla de HomeScreen con los permisos de ubicación ya dados y el GPS prendido.

 Pequeña corrección al echo de apagar el GPS no hacia que el ultimo punto en el que estuviste desapareciera, además que si entrabas a HomeScreen con el GPS apagado y lo prendías nunca iba a aparecer a no ser que cambiaras de screen y regresaras.
 